### PR TITLE
Add environment to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
       - main # You may need to change this to master
       - develop
 
+environment: production
+
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Since the repo is public, we need to add protection rules and restrict who can publish the package